### PR TITLE
Change encoding of the Output JSON to UTF-8 instead of UTF-8 BOM

### DIFF
--- a/Invoke-AtomicAssessment.ps1
+++ b/Invoke-AtomicAssessment.ps1
@@ -171,8 +171,10 @@ function Invoke-AtomicAssessment {
     $timestamp = Get-Date -Format "yyyyMMddHHmmss"
     $outputFileName = "$outputDir\$Adversary`_result_$hostname`_$timestamp.json"
 
-    # Output the final JSON object
-    $finalResult | ConvertTo-Json -Depth 10 | Out-File -FilePath $outputFileName -Encoding utf8
+    # Output the final JSON object, in UTF-8
+    $jsonContent = $finalResult | ConvertTo-Json -Depth 10
+    $utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $false
+    [System.IO.File]::WriteAllText($outputFileName, $jsonContent, $utf8NoBomEncoding)
 
     # Delete the temporary folder
     Remove-Item -Recurse -Force -Path $outputPath  


### PR DESCRIPTION
The generated JSON in the output folder use the UTF-8 BOM encoding. To avoid encoding issue it is better to use standard UTF-8 I guess so I fix it to generate an UTF-8 encoded JSON.

https://stackoverflow.com/questions/2223882/whats-the-difference-between-utf-8-and-utf-8-with-bom