### PR TITLE
Change encoding to UTF-8, add a workaround to import log without errors in VECTR, Set Output dir to the current path in the output folder

### DIFF
--- a/Invoke-AtomicAssessment.ps1
+++ b/Invoke-AtomicAssessment.ps1
@@ -171,8 +171,10 @@ function Invoke-AtomicAssessment {
     $timestamp = Get-Date -Format "yyyyMMddHHmmss"
     $outputFileName = "$outputDir\$Adversary`_result_$hostname`_$timestamp.json"
 
-    # Output the final JSON object
-    $finalResult | ConvertTo-Json -Depth 10 | Out-File -FilePath $outputFileName -Encoding utf8
+    # Output the final JSON object, in UTF-8
+    $jsonContent = $finalResult | ConvertTo-Json -Depth 10
+    $utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $false
+    [System.IO.File]::WriteAllText($outputFileName, $jsonContent, $utf8NoBomEncoding)
 
     # Delete the temporary folder
     Remove-Item -Recurse -Force -Path $outputPath  

--- a/Invoke-AtomicAssessment.ps1
+++ b/Invoke-AtomicAssessment.ps1
@@ -139,7 +139,7 @@ function Invoke-AtomicAssessment {
     # Get dynamic information
     $username = Get-UserInfo
     $hostname = Get-HostInfo
-    $ip_address = Get-IPInfo
+    $ip_address = (Get-NetIPAddress -AddressFamily IPv4 | Select-Object -First 1).IPAddress
     $executionID = Generate-ExecutionID
 
     # Create the final JSON object with the additional parameters
@@ -164,7 +164,7 @@ function Invoke-AtomicAssessment {
     }
 
     # Define output directory and filename
-    $outputDir = ".\output"
+    $outputDir = (Get-Location).Path+"\output"
     if (-not (Test-Path $outputDir)) {
         New-Item -ItemType Directory -Path $outputDir | Out-Null
     }


### PR DESCRIPTION
- Change encoding of the JSON output to _UTF-8_ instead of _UTF-8 BOM_. The generated JSON in the output folder use the _UTF-8 BOM_ encoding. To avoid encoding issue it is better to use standard _UTF-8_. I fix it to generate an UTF-8 encoded JSON. https://stackoverflow.com/questions/2223882/whats-the-difference-between-utf-8-and-utf-8-with-bom

- I also set the `$outputDir` variable to the output folder in the effective current Path with `$outputDir = (Get-Location).Path+"\output"` in order to avoid errors related to the output dir not found in some cases.

- Issue in the `$ip_address` variable that result in _null_ as value, the _Import log_ feature in VECTR https://github.com/SecurityRiskAdvisors/VECTR need a string in this variable, and not an object or null. I update it to have only the first returned IP address on the host to be able to import it in VECTR. I opened an issue on the VECTR project to update the JSON parser but in the meantime I supposed it is an acceptable workaround.
